### PR TITLE
First test

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -1,3 +1,7 @@
+from collections import namedtuple
+from functools import partial
+
+
 class VetPlugin:
     name = "flake8-pandas-vet"
     version = "0.1.0"
@@ -8,3 +12,12 @@ class VetPlugin:
     def run(self):
         for message in []:
             yield message
+
+
+error = namedtuple("Error", ["lineno", "col", "message", "type"])
+Error = partial(partial, error, type=VetPlugin)
+
+
+PD001 = Error(
+    "pandas should always be imported as 'import pandas as pd'"
+)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ requires = [
     "flake8 > 3.0.0",
 ]
 
+tests_requires = [
+    "pytest > 4.0.0"
+]
+
 flake8_entry_point = 'flake8.extension'
 
 setuptools.setup(
@@ -18,6 +22,7 @@ setuptools.setup(
         "pandas_vet",
     ],
     install_requires=requires,
+    tests_require=tests_requires,
     entry_points={
         flake8_entry_point: [
             'PD00 = pandas_vet:VetPlugin',

--- a/test/test_PD001.py
+++ b/test/test_PD001.py
@@ -1,0 +1,38 @@
+# stdlib
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD001
+
+
+def test_PD001_pass():
+    """
+    Test that importing pandas the recommended way does not result in an error.
+    """
+    statement = "import pandas as pd"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD001_fail_no_as():
+    """
+    Test that importing pandas without an 'as' clause results in an error.
+    """
+    statement = "import pandas"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD001(1, 1)]
+    assert actual == expected
+
+
+def test_PD001_fail_wrong_alias():
+    """
+    Test that importing pandas with an odd name results in an error.
+    """
+    statement = "import pandas as foo"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD001(1, 1)]
+    assert actual == expected


### PR DESCRIPTION
This PR bring in our first error, PD001, for bad imports, as well as 3 test cases that try to exercise that error.


Testing:
```
wjavins@work:~/git/pandas-vet$ pytest                                                                                                      [1]
============================================================= test session starts =============================================================
platform darwin -- Python 3.6.5, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: /Users/wjavins/git/pandas-vet, inifile:
collected 3 items                                                                                                                             

test/test_PD001.py .FF                                                                                                                  [100%]

================================================================== FAILURES ===================================================================
____________________________________________________________ test_PD001_fail_no_as ____________________________________________________________

    def test_PD001_fail_no_as():
        """
        Test that importing pandas without an 'as' clause results in an error.
        """
        statement = "import pandas"
        tree = ast.parse(statement)
        actual = list(VetPlugin(tree).run())
        expected = [PD001(1, 1)]
>       assert actual == expected
E       assert [] == [Error(lineno="pandas should...ss 'pandas_vet.VetPlugin'>)]
E         Right contains more items, first extra item: Error(lineno="pandas should always be imported as 'import pandas as pd'", col=1, message=1, type=<class 'pandas_vet.VetPlugin'>)
E         Use -v to get the full diff

test/test_PD001.py:27: AssertionError
_________________________________________________________ test_PD001_fail_wrong_alias _________________________________________________________

    def test_PD001_fail_wrong_alias():
        """
        Test that importing pandas with an odd name results in an error.
        """
        statement = "import pandas as foo"
        tree = ast.parse(statement)
        actual = list(VetPlugin(tree).run())
        expected = [PD001(1, 1)]
>       assert actual == expected
E       assert [] == [Error(lineno="pandas should...ss 'pandas_vet.VetPlugin'>)]
E         Right contains more items, first extra item: Error(lineno="pandas should always be imported as 'import pandas as pd'", col=1, message=1, type=<class 'pandas_vet.VetPlugin'>)
E         Use -v to get the full diff

test/test_PD001.py:38: AssertionError
===================================================== 2 failed, 1 passed in 0.11 seconds ======================================================
```