### PR TITLE
shorten the error code prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     tests_require=tests_requires,
     entry_points={
         flake8_entry_point: [
-            'PD00 = pandas_vet:VetPlugin',
+            'PD = pandas_vet:VetPlugin',
         ],
     },
     classifiers=[


### PR DESCRIPTION
Change from `PD00`. Better to use `PD` so that we can use the digits