### PR TITLE
Refactor tests to group by error number.

### DIFF
--- a/tests/test_PD001.py
+++ b/tests/test_PD001.py
@@ -2,7 +2,7 @@
 import ast
 
 from pandas_vet import VetPlugin
-from pandas_vet import PD001, PD002, PD003, PD004
+from pandas_vet import PD001
 
 
 def test_PD001_pass():
@@ -35,72 +35,6 @@ def test_PD001_fail_wrong_alias():
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
     expected = [PD001(1, 0)]
-    assert actual == expected
-
-
-def test_PD002_pass():
-    """
-    Test that using inplace=False explicitly does not result in an error.
-    """
-    statement = """df.drop(['a'], axis=1, inplace=False)"""
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = []
-    assert actual == expected
-
-
-def test_PD002_fail():
-    """
-    Test that using inplace=True results in an error.
-    """
-    statement = """df.drop(['a'], axis=1, inplace=True)"""
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = [PD002(1, 0)]
-    assert actual == expected
-
-
-def test_PD003_pass():
-    """
-    Test that using .isna() explicitly does not result in an error.
-    """
-    statement = "nas = pd.isna(val)"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = []
-    assert actual == expected
-
-
-def test_PD003_fail():
-    """
-    Test that using .isnull() results in an error.
-    """
-    statement = "nulls = pd.isnull(val)"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = [PD003(1, 8)]
-    assert actual == expected
-
-
-def test_PD004_pass():
-    """
-    Test that using .notna() explicitly does not result in an error.
-    """
-    statement = "notnas = pd.notna(val)"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = []
-    assert actual == expected
-
-
-def test_PD004_fail():
-    """
-    Test that using .notnull() results in an error.
-    """
-    statement = "notnulls = pd.notnull(val)"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = [PD004(1, 11)]
     assert actual == expected
 
 

--- a/tests/test_PD002.py
+++ b/tests/test_PD002.py
@@ -1,0 +1,29 @@
+# stdlib
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD002
+
+
+def test_PD002_pass():
+    """
+    Test that using inplace=False explicitly does not result in an error.
+    """
+    statement = """df.drop(['a'], axis=1, inplace=False)"""
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD002_fail():
+    """
+    Test that using inplace=True results in an error.
+    """
+    statement = """df.drop(['a'], axis=1, inplace=True)"""
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD002(1, 0)]
+    assert actual == expected
+
+

--- a/tests/test_PD003.py
+++ b/tests/test_PD003.py
@@ -1,0 +1,29 @@
+# stdlib
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD003
+
+
+def test_PD003_pass():
+    """
+    Test that using .isna() explicitly does not result in an error.
+    """
+    statement = "nas = pd.isna(val)"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD003_fail():
+    """
+    Test that using .isnull() results in an error.
+    """
+    statement = "nulls = pd.isnull(val)"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD003(1, 8)]
+    assert actual == expected
+
+

--- a/tests/test_PD004.py
+++ b/tests/test_PD004.py
@@ -1,0 +1,29 @@
+# stdlib
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD004
+
+
+def test_PD004_pass():
+    """
+    Test that using .notna() explicitly does not result in an error.
+    """
+    statement = "notnas = pd.notna(val)"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD004_fail():
+    """
+    Test that using .notnull() results in an error.
+    """
+    statement = "notnulls = pd.notnull(val)"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD004(1, 11)]
+    assert actual == expected
+
+


### PR DESCRIPTION
Closes #26.  
Separate modules for each linter error number, including all corresponding test signatures.