### PR TITLE
Add check for use of '.ix'.

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -26,6 +26,7 @@ class Visitor(ast.NodeVisitor):
         self.errors.extend(check_inplace_false(node))
         self.errors.extend(check_for_isnull(node))
         self.errors.extend(check_for_notnull(node))
+        self.errors.extend(check_for_ix(node))
 
     def check(self, node):
         self.errors = []
@@ -74,6 +75,13 @@ def check_for_notnull(node: ast.Call) -> List:
     return errors
 
 
+def check_for_ix(node: ast.Call) -> List:
+    errors = []
+    if node.func.attr == "ix":
+        errors.append(PD007(node.lineno, node.col_offset))
+    return errors
+
+
 error = namedtuple("Error", ["lineno", "col", "message", "type"])
 VetError = partial(partial, error, type=VetPlugin)
 
@@ -94,4 +102,7 @@ PD005 = VetError(
 )
 PD006 = VetError(
     message="Use comparison operator instead of method"
+)
+PD007 = VetError(
+    message="'.ix' is deprecated; use more explicit '.loc' or '.iloc'"
 )

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -26,6 +26,9 @@ class Visitor(ast.NodeVisitor):
         self.errors.extend(check_inplace_false(node))
         self.errors.extend(check_for_isnull(node))
         self.errors.extend(check_for_notnull(node))
+
+    def visit_Subscript(self, node):
+        self.generic_visit(node)  # continue checking children
         self.errors.extend(check_for_ix(node))
 
     def check(self, node):
@@ -75,9 +78,9 @@ def check_for_notnull(node: ast.Call) -> List:
     return errors
 
 
-def check_for_ix(node: ast.Call) -> List:
+def check_for_ix(node: ast.Subscript) -> List:
     errors = []
-    if node.func.attr == "ix":
+    if node.value.attr == "ix":
         errors.append(PD007(node.lineno, node.col_offset))
     return errors
 

--- a/tests/test_PD007.py
+++ b/tests/test_PD007.py
@@ -7,7 +7,7 @@ from pandas_vet import PD007
 
 def test_PD007_pass_loc():
     """
-    Test that using .loc() explicitly does not result in an error.
+    Test that using .loc[] explicitly does not result in an error.
     """
     statement = "new_df = df.loc['d':, 'A':'C']"
     tree = ast.parse(statement)
@@ -18,7 +18,7 @@ def test_PD007_pass_loc():
 
 def test_PD007_pass_iloc():
     """
-    Test that using .iloc() explicitly does not result in an error.
+    Test that using .iloc[] explicitly does not result in an error.
     """
     statement = "new_df = df.iloc[[1, 3, 5], [1, 3]]"
     tree = ast.parse(statement)
@@ -29,7 +29,7 @@ def test_PD007_pass_iloc():
 
 def test_PD007_fail():
     """
-    Test that using .ix() results in an error.
+    Test that using .ix[] results in an error.
     """
     statement = "s = df.ix[[0, 2], 'A']"
     tree = ast.parse(statement)

--- a/tests/test_PD007.py
+++ b/tests/test_PD007.py
@@ -1,0 +1,40 @@
+# stdlib
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD007
+
+
+def test_PD007_pass_loc():
+    """
+    Test that using .loc() explicitly does not result in an error.
+    """
+    statement = "index = pd.loc(val)"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD007_pass_iloc():
+    """
+    Test that using .iloc() explicitly does not result in an error.
+    """
+    statement = "index = pd.iloc(val)"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD007_fail():
+    """
+    Test that using .ix() results in an error.
+    """
+    statement = "index = pd.ix(val)"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD007(1, 8)]
+    assert actual == expected
+
+

--- a/tests/test_PD007.py
+++ b/tests/test_PD007.py
@@ -9,7 +9,7 @@ def test_PD007_pass_loc():
     """
     Test that using .loc() explicitly does not result in an error.
     """
-    statement = "index = pd.loc(val)"
+    statement = "new_df = df.loc['d':, 'A':'C']"
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
     expected = []
@@ -20,7 +20,7 @@ def test_PD007_pass_iloc():
     """
     Test that using .iloc() explicitly does not result in an error.
     """
-    statement = "index = pd.iloc(val)"
+    statement = "new_df = df.iloc[[1, 3, 5], [1, 3]]"
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
     expected = []
@@ -31,10 +31,10 @@ def test_PD007_fail():
     """
     Test that using .ix() results in an error.
     """
-    statement = "index = pd.ix(val)"
+    statement = "s = df.ix[[0, 2], 'A']"
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
-    expected = [PD007(1, 8)]
+    expected = [PD007(1, 4)]
     assert actual == expected
 
 


### PR DESCRIPTION
Created new PD007 error code and check function.  Tests include allowing for '.loc' and '.iloc'.

Closes #29 