### PR TITLE
Add check for use of '.values' attribute.

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -18,10 +18,22 @@ class Visitor(ast.NodeVisitor):
     errors = attr.ib(default=attr.Factory(list))
 
     def visit_Import(self, node):
+        """ 
+        Called for `import ..` and `import .. as ..` nodes.
+        """
         self.generic_visit(node)  # continue checking children
         self.errors.extend(check_import_name(node))
 
+    def visit_ImportFrom(self, node):
+        """ 
+        Called for `from .. import ..` nodes.
+        """
+        self.generic_visit(node)  # continue checking children
+
     def visit_Call(self, node):
+        """ 
+        Called for `.method()` nodes.
+        """
         self.generic_visit(node)  # continue checking children
         self.errors.extend(check_inplace_false(node))
         self.errors.extend(check_for_isnull(node))
@@ -30,10 +42,18 @@ class Visitor(ast.NodeVisitor):
         self.errors.extend(check_for_unstack(node))
 
     def visit_Subscript(self, node):
+        """ 
+        Called for `[slicing]` nodes.
+        """
         self.generic_visit(node)  # continue checking children
         self.errors.extend(check_for_ix(node))
         self.errors.extend(check_for_at(node))
         self.errors.extend(check_for_iat(node))
+
+    def visit_Attribute(self, node):
+        """ 
+        Called for `.attribute` nodes.
+        """
         self.errors.extend(check_for_values(node))
 
     def check(self, node):
@@ -138,7 +158,7 @@ def check_for_values(node: ast.Call) -> List:
     PandasArray, or `.to_array()` method for NumPy array.
     """
     errors = []
-    if node.value.attr == "values":
+    if node.attr == "values":
         errors.append(PD011(node.lineno, node.col_offset))
     return errors
 

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -24,12 +24,6 @@ class Visitor(ast.NodeVisitor):
         self.generic_visit(node)  # continue checking children
         self.errors.extend(check_import_name(node))
 
-    def visit_ImportFrom(self, node):
-        """ 
-        Called for `from .. import ..` nodes.
-        """
-        self.generic_visit(node)  # continue checking children
-
     def visit_Call(self, node):
         """ 
         Called for `.method()` nodes.
@@ -149,17 +143,16 @@ def check_for_unstack(node: ast.Call) -> List:
     return []
 
 
-def check_for_values(node: ast.Call) -> List:
+def check_for_values(node: ast.Attribute) -> List:
     """
     Check AST for occurence of the `.values` attribute on the pandas data frame.
 
     Error/warning message to recommend use of `.array` data frame attribute for
     PandasArray, or `.to_array()` method for NumPy array.
     """
-    errors = []
     if node.attr == "values":
-        errors.append(PD011(node.lineno, node.col_offset))
-    return errors
+        return [PD011(node.lineno, node.col_offset)]
+    return []
 
 
 error = namedtuple("Error", ["lineno", "col", "message", "type"])

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -34,6 +34,7 @@ class Visitor(ast.NodeVisitor):
         self.errors.extend(check_for_ix(node))
         self.errors.extend(check_for_at(node))
         self.errors.extend(check_for_iat(node))
+        self.errors.extend(check_for_values(node))
 
     def check(self, node):
         self.errors = []
@@ -129,6 +130,19 @@ def check_for_unstack(node: ast.Call) -> List:
     return errors
 
 
+def check_for_values(node: ast.Call) -> List:
+    """
+    Check AST for occurence of the `.values` attribute on the pandas data frame.
+
+    Error/warning message to recommend use of `.array` data frame attribute for
+    PandasArray, or `.to_array()` method for NumPy array.
+    """
+    errors = []
+    if node.value.attr == "values":
+        errors.append(PD011(node.lineno, node.col_offset))
+    return errors
+
+
 error = namedtuple("Error", ["lineno", "col", "message", "type"])
 VetError = partial(partial, error, type=VetPlugin)
 
@@ -161,5 +175,8 @@ PD009 = VetError(
 )
 PD010 = VetError(
     message="'.pivot_table' is preferred to '.pivot' or '.unstack'; provides same functionality"
+)
+PD011 = VetError(
+    message="Use '.array' or '.to_array()' instead of '.values'; 'values' is ambiguous"
 )
 

--- a/tests/test_PD011.py
+++ b/tests/test_PD011.py
@@ -40,4 +40,12 @@ def test_PD011_fail_values():
     expected = [PD011(1, 9)]
     assert actual == expected
 
-
+def test_PD011_pass_node_Name():
+    """
+    Test that where 'values' is a Name does NOT raise an error
+    """
+    statement = "result = values"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected

--- a/tests/test_PD011.py
+++ b/tests/test_PD011.py
@@ -1,0 +1,43 @@
+"""
+Test to check for use of the pandas dataframe `.array` attribute 
+or `.to_array()` method in preference to `.values` attribute.  
+"""
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD011
+
+
+def test_PD011_pass_array():
+    """
+    Test that using .array explicitly does not result in an error.
+    """
+    statement = "result = df.array"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD011_pass_to_array():
+    """
+    Test that using .to_array() explicitly does not result in an error.
+    """
+    statement = "result = df.to_array()"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD011_fail_values():
+    """
+    Test that using .values data frame attribute results in an error.
+    """
+    statement = "result = df.values"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+

--- a/tests/test_PD011.py
+++ b/tests/test_PD011.py
@@ -37,7 +37,7 @@ def test_PD011_fail_values():
     statement = "result = df.values"
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
-    expected = []
+    expected = [PD011(1, 9)]
     assert actual == expected
 
 

--- a/tests/test_PD011.py
+++ b/tests/test_PD011.py
@@ -8,22 +8,22 @@ from pandas_vet import VetPlugin
 from pandas_vet import PD011
 
 
-def test_PD011_pass_array():
+def test_PD011_pass_to_array():
     """
-    Test that using .array explicitly does not result in an error.
+    Test that using .to_array() explicitly does not result in an error.
     """
-    statement = "result = df.array"
+    statement = "result = df.to_array()"
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
     expected = []
     assert actual == expected
 
 
-def test_PD011_pass_to_array():
+def test_PD011_pass_array():
     """
-    Test that using .to_array() explicitly does not result in an error.
+    Test that using .array explicitly does not result in an error.
     """
-    statement = "result = df.to_array()"
+    statement = "result = df.array"
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
     expected = []


### PR DESCRIPTION
Linter error PD011 when using `.values` attribute on pandas dataframe object.  No error when using either `.array` attribute or `.to_array()` method.  