### PR TITLE
Don't throw errors on print()

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -41,6 +41,10 @@ class Visitor(ast.NodeVisitor):
         return self.errors
 
 
+class PandasVetException(Exception):
+    pass
+
+
 class VetPlugin:
     name = "flake8-pandas-vet"
     version = __version__
@@ -49,7 +53,10 @@ class VetPlugin:
         self.tree = tree
 
     def run(self):
-        return Visitor().check(self.tree)
+        try:
+            return Visitor().check(self.tree)
+        except Exception as e:
+            raise PandasVetException(e)
 
 
 def check_import_name(node: ast.Import) -> List:

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -76,38 +76,32 @@ def check_inplace_false(node: ast.Call) -> List:
 
 
 def check_for_isnull(node: ast.Call) -> List:
-    errors = []
     if isinstance(node.func, ast.Attribute) and node.func.attr == "isnull":
-        errors.append(PD003(node.lineno, node.col_offset))
-    return errors
+        return [PD003(node.lineno, node.col_offset)]
+    return []
 
 
 def check_for_notnull(node: ast.Call) -> List:
-    errors = []
     if isinstance(node.func, ast.Attribute) and node.func.attr == "notnull":
-        errors.append(PD004(node.lineno, node.col_offset))
-    return errors
-
+        return [PD004(node.lineno, node.col_offset)]
+    return []
 
 def check_for_ix(node: ast.Subscript) -> List:
-    errors = []
     if node.value.attr == "ix":
-        errors.append(PD007(node.lineno, node.col_offset))
-    return errors
+        return [PD007(node.lineno, node.col_offset)]
+    return []
 
 
 def check_for_at(node: ast.Call) -> List:
-    errors = []
     if node.value.attr == "at":
-        errors.append(PD008(node.lineno, node.col_offset))
-    return errors
+        return [PD008(node.lineno, node.col_offset)]
+    return []
 
 
 def check_for_iat(node: ast.Call) -> List:
-    errors = []
     if node.value.attr == "iat":
-        errors.append(PD009(node.lineno, node.col_offset))
-    return errors
+        return [PD009(node.lineno, node.col_offset)]
+    return []
 
 
 def check_for_pivot(node: ast.Call) -> List:
@@ -118,10 +112,9 @@ def check_for_pivot(node: ast.Call) -> List:
     This check should work for both the `df.pivot()` method, as well as the
     `pd.pivot(df)` function.
     """
-    errors = []
     if isinstance(node.func, ast.Attribute) and node.func.attr == "pivot":
-        errors.append(PD010(node.lineno, node.col_offset))
-    return errors
+        return [PD010(node.lineno, node.col_offset)]
+    return []
 
 
 def check_for_unstack(node: ast.Call) -> List:
@@ -130,10 +123,9 @@ def check_for_unstack(node: ast.Call) -> List:
 
     Error/warning message to recommend use of `.pivot_table()` method instead.
     """
-    errors = []
     if isinstance(node.func, ast.Attribute) and node.func.attr == "unstack":
-        errors.append(PD010(node.lineno, node.col_offset))
-    return errors
+        return [PD010(node.lineno, node.col_offset)]
+    return []
 
 
 error = namedtuple("Error", ["lineno", "col", "message", "type"])

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -77,14 +77,14 @@ def check_inplace_false(node: ast.Call) -> List:
 
 def check_for_isnull(node: ast.Call) -> List:
     errors = []
-    if node.func.attr == "isnull":
+    if isinstance(node.func, ast.Attribute) and node.func.attr == "isnull":
         errors.append(PD003(node.lineno, node.col_offset))
     return errors
 
 
 def check_for_notnull(node: ast.Call) -> List:
     errors = []
-    if node.func.attr == "notnull":
+    if isinstance(node.func, ast.Attribute) and node.func.attr == "notnull":
         errors.append(PD004(node.lineno, node.col_offset))
     return errors
 
@@ -119,7 +119,7 @@ def check_for_pivot(node: ast.Call) -> List:
     `pd.pivot(df)` function.
     """
     errors = []
-    if node.func.attr == "pivot":
+    if isinstance(node.func, ast.Attribute) and node.func.attr == "pivot":
         errors.append(PD010(node.lineno, node.col_offset))
     return errors
 
@@ -131,7 +131,7 @@ def check_for_unstack(node: ast.Call) -> List:
     Error/warning message to recommend use of `.pivot_table()` method instead.
     """
     errors = []
-    if node.func.attr == "unstack":
+    if isinstance(node.func, ast.Attribute) and node.func.attr == "unstack":
         errors.append(PD010(node.lineno, node.col_offset))
     return errors
 

--- a/tests/test_PD003.py
+++ b/tests/test_PD003.py
@@ -27,3 +27,8 @@ def test_PD003_fail():
     assert actual == expected
 
 
+def test_allows_other_function_calls():
+    statement = "print('bah humbug')"
+    tree = ast.parse(statement)
+    result = VetPlugin(tree).run()
+    assert result == []


### PR DESCRIPTION
Linting code that contained calls to builtins() was failing because we were assuming that all functions that were being called were attributes of something. Some of them are just already in the global namespace!

This PR also:

* wraps exceptions we throw in a PandasVetException to avoid propagating an AttributeError to flake8, since flake8 misinterprets that and masks the real error
* adds test cases to catch the failure
* makes a mostly aesthetic change to avoid appending to lists in functions where the return value can only have 0 or 1 elements