### PR TITLE
fix check_for_ix, check_for_at, check_for_iat checks

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -86,21 +86,34 @@ def check_for_notnull(node: ast.Call) -> List:
         return [PD004(node.lineno, node.col_offset)]
     return []
 
+
 def check_for_ix(node: ast.Subscript) -> List:
-    if node.value.attr == "ix":
-        return [PD007(node.lineno, node.col_offset)]
+    if isinstance(node.value, ast.Name):
+        if node.value.id == "ix":
+            return [PD007(node.lineno, node.col_offset)]
+    elif isinstance(node.value, ast.Attribute):
+        if node.value.attr == 'ix':
+            return [PD007(node.lineno, node.col_offset)]
     return []
 
 
-def check_for_at(node: ast.Call) -> List:
-    if node.value.attr == "at":
-        return [PD008(node.lineno, node.col_offset)]
+def check_for_at(node: ast.Subscript) -> List:
+    if isinstance(node.value, ast.Name):
+        if node.value.id == "at":
+            return [PD008(node.lineno, node.col_offset)]
+    elif isinstance(node.value, ast.Attribute):
+        if node.value.attr == 'at':
+            return [PD008(node.lineno, node.col_offset)]
     return []
 
 
-def check_for_iat(node: ast.Call) -> List:
-    if node.value.attr == "iat":
-        return [PD009(node.lineno, node.col_offset)]
+def check_for_iat(node: ast.Subscript) -> List:
+    if isinstance(node.value, ast.Name):
+        if node.value.id == "iat":
+            return [PD009(node.lineno, node.col_offset)]
+    elif isinstance(node.value, ast.Attribute):
+        if node.value.attr == 'iat':
+            return [PD009(node.lineno, node.col_offset)]
     return []
 
 

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -88,32 +88,20 @@ def check_for_notnull(node: ast.Call) -> List:
 
 
 def check_for_ix(node: ast.Subscript) -> List:
-    if isinstance(node.value, ast.Name):
-        if node.value.id == "ix":
-            return [PD007(node.lineno, node.col_offset)]
-    elif isinstance(node.value, ast.Attribute):
-        if node.value.attr == 'ix':
-            return [PD007(node.lineno, node.col_offset)]
+    if isinstance(node.value, ast.Attribute) and node.value.attr == 'ix':
+        return [PD007(node.lineno, node.col_offset)]
     return []
 
 
 def check_for_at(node: ast.Subscript) -> List:
-    if isinstance(node.value, ast.Name):
-        if node.value.id == "at":
-            return [PD008(node.lineno, node.col_offset)]
-    elif isinstance(node.value, ast.Attribute):
-        if node.value.attr == 'at':
-            return [PD008(node.lineno, node.col_offset)]
+    if isinstance(node.value, ast.Attribute) and node.value.attr == 'at':
+        return [PD008(node.lineno, node.col_offset)]
     return []
 
 
 def check_for_iat(node: ast.Subscript) -> List:
-    if isinstance(node.value, ast.Name):
-        if node.value.id == "iat":
-            return [PD009(node.lineno, node.col_offset)]
-    elif isinstance(node.value, ast.Attribute):
-        if node.value.attr == 'iat':
-            return [PD009(node.lineno, node.col_offset)]
+    if isinstance(node.value, ast.Attribute) and node.value.attr == 'iat':
+        return [PD009(node.lineno, node.col_offset)]
     return []
 
 

--- a/tests/test_PD007.py
+++ b/tests/test_PD007.py
@@ -38,3 +38,12 @@ def test_PD007_fail():
     assert actual == expected
 
 
+def test_PD007_node_value_Name_pass():
+    """
+    Test that an ast.Subscript where node.value is a Name does NOT raise an error
+    """
+    statement = "s = ix[[0, 2], 'A']"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected

--- a/tests/test_PD008.py
+++ b/tests/test_PD008.py
@@ -27,3 +27,12 @@ def test_PD008_fail():
     assert actual == expected
 
 
+def test_PD008_node_value_Name_pass():
+    """
+    Test that an ast.Subscript where node.value is a Name does NOT raise an error
+    """
+    statement = "s = at[[0, 2], 'A']"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected

--- a/tests/test_PD009.py
+++ b/tests/test_PD009.py
@@ -27,3 +27,12 @@ def test_PD009_fail():
     assert actual == expected
 
 
+def test_PD009_node_value_Name_pass():
+    """
+    Test that an ast.Subscript where node.value is a Name does NOT raise an error
+    """
+    statement = "s = iat[[0, 2], 'A']"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected


### PR DESCRIPTION
These functions now check the type of `node.value`. `node.value` can be either a `Name` or `Attribute`, which do not have matching attributes. Before you can check whether it matches the desired pattern (i.e., `ix`, `at`, `iat`), you need to figure out if you are working with a `Name` or `Attribute`.

If `node.value` is `ast.Name`, use `node.value.id`. 

If `node.value` is `ast.Attribute`, use `node.value.attr`.

Closes #44 