### PR TITLE
Implement check for groupby slicing and aggregation patterns.

### DIFF
--- a/tests/test_PD011.py
+++ b/tests/test_PD011.py
@@ -1,6 +1,6 @@
 """
-Test to check for use of the pandas dataframe `.array` attribute 
-or `.to_array()` method in preference to `.values` attribute.  
+Test to check for use of the pandas dataframe `.array` attribute
+or `.to_array()` method in preference to `.values` attribute.
 """
 import ast
 
@@ -39,6 +39,7 @@ def test_PD011_fail_values():
     actual = list(VetPlugin(tree).run())
     expected = [PD011(1, 9)]
     assert actual == expected
+
 
 def test_PD011_pass_node_Name():
     """

--- a/tests/test_PD014.py
+++ b/tests/test_PD014.py
@@ -1,0 +1,167 @@
+"""
+Test to check for use of the slicing syntax with `.groupby()` method
+
+Valid patterns:
+    groupby('group_col')
+    groupby('group_col').agg('agg_col')
+    groupby('group_col').agg('agg_func')
+    groupby('group_col').agg({'agg_col': 'agg_func'})
+    df.groupby('group_col')
+    df.groupby('group_col').agg('agg_col')
+    df.groupby('group_col').agg('agg_func')
+    df.groupby('group_col').agg({'agg_col': 'agg_func'})
+
+Invalid patterns:
+    groupby('group_col')['agg_col']
+    groupby('group_col')['agg_col'].agg('agg_func')
+    groupby('group_col')['agg_col'].agg_func()
+    df.groupby('group_col')['agg_col']
+    df.groupby('group_col')['agg_col'].agg('agg_func')
+    df.groupby('group_col')['agg_col'].agg_func()
+
+NOTE:
+    For function calls, function name is in node.value.func.id
+    For method  calls, function name is in node.value.func.attr
+"""
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD014
+
+
+### 2019.03.07 TESTS DON'T YET EXIST FOR ALL PATTERNS ABOVE
+
+def test_PD014_pass_groupby_method_with_no_slicing():
+    """
+    Test that using .groupby() without slicing does not result in an error.
+    """
+    statement = "df.groupby('group_col')"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD014_pass_groupby_method_with_no_slicing_with_agg_method():
+    """
+    Test that using .groupby().agg() without slicing does not result in an error.
+    """
+    statement = "df.groupby('group_col').agg('agg_func')"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD014_pass_groupby_method_with_no_slicing_with_agg_columns():
+    """
+    Test that using .groupby().agg() without slicing does not result in an error.
+    """
+    statement = "df.groupby('group_col').agg({'agg_col': 'agg_func'})"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD014_fail_groupby_method_with_slicing():
+    """
+    Test that using .groupby()[] syntax results in an error.
+    """
+    statement = "df.groupby('group_col')['agg_col']"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD014(1, 0)]
+    assert actual == expected
+
+
+def test_PD014_fail_groupby_method_with_slicing_and_agg_method():
+    """
+    Test that using .groupby()[].agg() syntax results in an error.
+    """
+    statement = "df.groupby('group_col')['agg_col'].agg('agg_func')"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD014(1, 0)]
+    assert actual == expected
+
+
+def test_PD014_fail_groupby_method_with_slicing_and_agg_func():
+    """
+    test that using .groupby()[].agg_func() syntax results in an error.
+    """
+    statement = "df.groupby('group_col')['agg_col'].agg_func()"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD014(1, 0)]
+    assert actual == expected
+
+
+
+# Below functions test for use of `groupby() function, independent of dataframe
+# DOES THIS MAKE ANY SENSE?
+
+def test_PD014_pass_groupby_function_with_no_slicing():
+    """
+    Test that using groupby() without slicing does not result in an error.
+    """
+    statement = "groupby('group_col')"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD014_pass_groupby_function_with_no_slicing_with_agg_method():
+    """
+    Test that using groupby().agg() without slicing does not result in an error.
+    """
+    statement = "groupby('group_col').agg('agg_func')"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD014_pass_groupby_function_with_no_slicing_with_agg_columns():
+    """
+    Test that using groupby().agg() without slicing does not result in an error.
+    """
+    statement = "groupby('group_col').agg({'agg_col': 'agg_func'})"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD014_fail_groupby_function_with_slicing():
+    """
+    Test that using groupby()[] syntax results in an error.
+    """
+    statement = "groupby('group_col')['agg_col']"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD014(1, 0)]
+    assert actual == expected
+
+
+def test_PD014_fail_groupby_function_with_slicing_and_agg_method():
+    """
+    Test that using groupby()[].agg() syntax results in an error.
+    """
+    statement = "groupby('group_col')['agg_col'].agg('agg_func')"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD014(1, 0)]
+    assert actual == expected
+
+
+def test_PD014_fail_groupby_function_with_slicing_and_agg_func():
+    """
+    test that using groupby()[].agg_func() syntax results in an error.
+    """
+    statement = "groupby('group_col')['agg_col'].agg_func()"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD014(1, 0)]
+    assert actual == expected

--- a/tests/test_PD014.py
+++ b/tests/test_PD014.py
@@ -1,7 +1,9 @@
 """
 Test to check for use of the slicing syntax with `.groupby()` method
 
-Valid patterns:
+### 2019.03.07 TESTS DON'T YET EXIST FOR ALL OF THESE PATTERNS
+
+Valid (?) patterns for `.groupby()` method:
     groupby('group_col')
     groupby('group_col').agg('agg_col')
     groupby('group_col').agg('agg_func')
@@ -11,7 +13,7 @@ Valid patterns:
     df.groupby('group_col').agg('agg_func')
     df.groupby('group_col').agg({'agg_col': 'agg_func'})
 
-Invalid patterns:
+Invalid patterns for `.groupby()` method:
     groupby('group_col')['agg_col']
     groupby('group_col')['agg_col'].agg('agg_func')
     groupby('group_col')['agg_col'].agg_func()
@@ -20,16 +22,29 @@ Invalid patterns:
     df.groupby('group_col')['agg_col'].agg_func()
 
 NOTE:
-    For function calls, function name is in node.value.func.id
     For method  calls, function name is in node.value.func.attr
+
+### 2019.03.07 IS THERE VALID SYNTAX FOR A `groupby()` FUNCTION CALL ?
+
+Valid (?) patterns for `groupby()` function:
+    groupby('group_col')
+    groupby('group_col').agg('agg_col')
+    groupby('group_col').agg('agg_func')
+    groupby('group_col').agg({'agg_col': 'agg_func'})
+
+Invalid patterns for `groupby()` function:
+    groupby('group_col')['agg_col']
+    groupby('group_col')['agg_col'].agg('agg_func')
+    groupby('group_col')['agg_col'].agg_func()
+
+NOTE:
+    For function calls, function name is in node.value.func.id
 """
 import ast
 
 from pandas_vet import VetPlugin
 from pandas_vet import PD014
 
-
-### 2019.03.07 TESTS DON'T YET EXIST FOR ALL PATTERNS ABOVE
 
 def test_PD014_pass_groupby_method_with_no_slicing():
     """
@@ -42,9 +57,9 @@ def test_PD014_pass_groupby_method_with_no_slicing():
     assert actual == expected
 
 
-def test_PD014_pass_groupby_method_with_no_slicing_with_agg_method():
+def test_pd014_pass_groupby_method_with_no_slicing_with_agg_method():
     """
-    Test that using .groupby().agg() without slicing does not result in an error.
+    test that using .groupby().agg() without slicing does not result in an error.
     """
     statement = "df.groupby('group_col').agg('agg_func')"
     tree = ast.parse(statement)
@@ -97,71 +112,70 @@ def test_PD014_fail_groupby_method_with_slicing_and_agg_func():
     assert actual == expected
 
 
-
-# Below functions test for use of `groupby() function, independent of dataframe
-# DOES THIS MAKE ANY SENSE?
-
-def test_PD014_pass_groupby_function_with_no_slicing():
-    """
-    Test that using groupby() without slicing does not result in an error.
-    """
-    statement = "groupby('group_col')"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = []
-    assert actual == expected
-
-
-def test_PD014_pass_groupby_function_with_no_slicing_with_agg_method():
-    """
-    Test that using groupby().agg() without slicing does not result in an error.
-    """
-    statement = "groupby('group_col').agg('agg_func')"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = []
-    assert actual == expected
-
-
-def test_PD014_pass_groupby_function_with_no_slicing_with_agg_columns():
-    """
-    Test that using groupby().agg() without slicing does not result in an error.
-    """
-    statement = "groupby('group_col').agg({'agg_col': 'agg_func'})"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = []
-    assert actual == expected
-
-
-def test_PD014_fail_groupby_function_with_slicing():
-    """
-    Test that using groupby()[] syntax results in an error.
-    """
-    statement = "groupby('group_col')['agg_col']"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = [PD014(1, 0)]
-    assert actual == expected
-
-
-def test_PD014_fail_groupby_function_with_slicing_and_agg_method():
-    """
-    Test that using groupby()[].agg() syntax results in an error.
-    """
-    statement = "groupby('group_col')['agg_col'].agg('agg_func')"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = [PD014(1, 0)]
-    assert actual == expected
-
-
-def test_PD014_fail_groupby_function_with_slicing_and_agg_func():
-    """
-    test that using groupby()[].agg_func() syntax results in an error.
-    """
-    statement = "groupby('group_col')['agg_col'].agg_func()"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = [PD014(1, 0)]
-    assert actual == expected
+## Below functions test for use of `groupby() function, independent of dataframe
+## DOES THIS MAKE ANY SENSE?
+#
+#def test_PD014_pass_groupby_function_with_no_slicing():
+#    """
+#    Test that using groupby() without slicing does not result in an error.
+#    """
+#    statement = "groupby('group_col')"
+#    tree = ast.parse(statement)
+#    actual = list(VetPlugin(tree).run())
+#    expected = []
+#    assert actual == expected
+#
+#
+#def test_PD014_pass_groupby_function_with_no_slicing_with_agg_method():
+#    """
+#    Test that using groupby().agg() without slicing does not result in an error.
+#    """
+#    statement = "groupby('group_col').agg('agg_func')"
+#    tree = ast.parse(statement)
+#    actual = list(VetPlugin(tree).run())
+#    expected = []
+#    assert actual == expected
+#
+#
+#def test_PD014_pass_groupby_function_with_no_slicing_with_agg_columns():
+#    """
+#    Test that using groupby().agg() without slicing does not result in an error.
+#    """
+#    statement = "groupby('group_col').agg({'agg_col': 'agg_func'})"
+#    tree = ast.parse(statement)
+#    actual = list(VetPlugin(tree).run())
+#    expected = []
+#    assert actual == expected
+#
+#
+#def test_PD014_fail_groupby_function_with_slicing():
+#    """
+#    Test that using groupby()[] syntax results in an error.
+#    """
+#    statement = "groupby('group_col')['agg_col']"
+#    tree = ast.parse(statement)
+#    actual = list(VetPlugin(tree).run())
+#    expected = [PD014(1, 0)]
+#    assert actual == expected
+#
+#
+#def test_PD014_fail_groupby_function_with_slicing_and_agg_method():
+#    """
+#    Test that using groupby()[].agg() syntax results in an error.
+#    """
+#    statement = "groupby('group_col')['agg_col'].agg('agg_func')"
+#    tree = ast.parse(statement)
+#    actual = list(VetPlugin(tree).run())
+#    expected = [PD014(1, 0)]
+#    assert actual == expected
+#
+#
+#def test_PD014_fail_groupby_function_with_slicing_and_agg_func():
+#    """
+#    test that using groupby()[].agg_func() syntax results in an error.
+#    """
+#    statement = "groupby('group_col')['agg_col'].agg_func()"
+#    tree = ast.parse(statement)
+#    actual = list(VetPlugin(tree).run())
+#    expected = [PD014(1, 0)]
+#    assert actual == expected

--- a/tests/test_PD014.py
+++ b/tests/test_PD014.py
@@ -59,7 +59,7 @@ def test_PD014_pass_groupby_method_with_no_slicing():
 
 def test_pd014_pass_groupby_method_with_no_slicing_with_agg_method():
     """
-    test that using .groupby().agg() without slicing does not result in an error.
+    test that .groupby().agg() without slicing does not result in an error.
     """
     statement = "df.groupby('group_col').agg('agg_func')"
     tree = ast.parse(statement)
@@ -70,7 +70,7 @@ def test_pd014_pass_groupby_method_with_no_slicing_with_agg_method():
 
 def test_PD014_pass_groupby_method_with_no_slicing_with_agg_columns():
     """
-    Test that using .groupby().agg() without slicing does not result in an error.
+    Test that .groupby().agg() without slicing does not result in an error.
     """
     statement = "df.groupby('group_col').agg({'agg_col': 'agg_func'})"
     tree = ast.parse(statement)
@@ -112,8 +112,8 @@ def test_PD014_fail_groupby_method_with_slicing_and_agg_func():
     assert actual == expected
 
 
-## Below functions test for use of `groupby() function, independent of dataframe
-## DOES THIS MAKE ANY SENSE?
+# Below functions test for use of `groupby() function, independent of dataframe
+# DOES THIS MAKE ANY SENSE?
 #
 #def test_PD014_pass_groupby_function_with_no_slicing():
 #    """
@@ -128,7 +128,7 @@ def test_PD014_fail_groupby_method_with_slicing_and_agg_func():
 #
 #def test_PD014_pass_groupby_function_with_no_slicing_with_agg_method():
 #    """
-#    Test that using groupby().agg() without slicing does not result in an error.
+#    Test that groupby().agg() without slicing does not result in an error.
 #    """
 #    statement = "groupby('group_col').agg('agg_func')"
 #    tree = ast.parse(statement)
@@ -139,7 +139,7 @@ def test_PD014_fail_groupby_method_with_slicing_and_agg_func():
 #
 #def test_PD014_pass_groupby_function_with_no_slicing_with_agg_columns():
 #    """
-#    Test that using groupby().agg() without slicing does not result in an error.
+#    Test that groupby().agg() without slicing does not result in an error.
 #    """
 #    statement = "groupby('group_col').agg({'agg_col': 'agg_func'})"
 #    tree = ast.parse(statement)


### PR DESCRIPTION
Pending determination of acceptable use cases for this pattern, this PR checks for explicit use of the following patterns with explicit slicing syntax on the `groupby()` method:

    df.groupby(A)[B]          # for ast.Subscript nodes
    df.groupby(A)[B].agg(C)   # for ast.Call nodes

Note that this requires two separate check functions due to above distinction in AST.  Also, includes check to distinguish between method (`node.func.attr`) vs. function (`node.func.id`).  

The implementation does not check syntax for functions, although commented tests are included in `test_PD014.py` in case this is determined to be acceptable syntax for check.  

Closes #24 (pending)