### PR TITLE
Issue/25/check for merge

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -243,10 +243,9 @@ def check_for_merge(node: ast.Call) -> List:
     # object.  If the object name is `pd`, and if the `.merge()` method has at
     # least two arguments (left, right, ... ) we will assume that it matches 
     # the pattern that we are trying to check, `pd.merge(left, right)`
-    #if not isinstance( XXX node parent XXX, 'module'): return []
     if not hasattr(node.func, 'value'): return []   # ignore functions
     if not node.func.value.id == 'pd': return[]     # assume object name is `pd`
-    if not len(node.args) >= 1: return []           # at least two arguments
+    if not len(node.args) >= 2: return []           # at least two arguments
     
     if isinstance(node.func, ast.Attribute) and \
        node.func.attr == "merge":

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -238,11 +238,20 @@ def check_for_merge(node: ast.Call) -> List:
 
     Error/warning message to recommend use of `df.merge()` method instead.
     """
-    pass        ### WIP - NOT YET IMPLEMENTED
-    # need to first determine if the method is applied to pandas or to dataframe
-    #if isinstance(node.func, ast.Attribute) and node.func.attr == "read_table":
-    #    return [PD014(node.lineno, node.col_offset)]
-    #return []
+    # The AST does not retain any of the pandas semantic information, so the
+    # current implementation of this test will infer based on the name of the
+    # object.  If the object name is `pd`, and if the `.merge()` method has at
+    # least two arguments (left, right, ... ) we will assume that it matches 
+    # the pattern that we are trying to check, `pd.merge(left, right)`
+    #if not isinstance( XXX node parent XXX, 'module'): return []
+    if not hasattr(node.func, 'value'): return []   # ignore functions
+    if not node.func.value.id == 'pd': return[]     # assume object name is `pd`
+    if not len(node.args) >= 1: return []           # at least two arguments
+    
+    if isinstance(node.func, ast.Attribute) and \
+       node.func.attr == "merge":
+        return [PD015(node.lineno, node.col_offset)]
+    return []
 
 
 error = namedtuple("Error", ["lineno", "col", "message", "type"])

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -41,6 +41,7 @@ class Visitor(ast.NodeVisitor):
         self.errors.extend(check_for_arithmetic_methods(node))
         self.errors.extend(check_for_comparison_methods(node))
         self.errors.extend(check_for_read_table(node))
+        self.errors.extend(check_for_merge(node))
 
     def visit_Subscript(self, node):
         """ 
@@ -228,6 +229,19 @@ def check_for_read_table(node: ast.Call) -> List:
     return []
 
 
+def check_for_merge(node: ast.Call) -> List:
+    """
+    Check for use of `.merge()` method on the pandas object.
+
+    Error/warning message to recommend use of `df.merge()` method instead.
+    """
+    pass        ### WIP - NOT YET IMPLEMENTED
+    # need to first determine if the method is applied to pandas or to dataframe
+    #if isinstance(node.func, ast.Attribute) and node.func.attr == "read_table":
+    #    return [PD014(node.lineno, node.col_offset)]
+    #return []
+
+
 error = namedtuple("Error", ["lineno", "col", "message", "type"])
 VetError = partial(partial, error, type=VetPlugin)
 
@@ -269,4 +283,7 @@ PD012 = VetError(
 )
 PD013 = VetError(
     message="PD013 '.melt' is preferred to '.stack'; provides same functionality"
+)
+PD015 = VetError(
+    message="PD015 Use '.merge' method instead of 'pd.merge' function. They have equivalent functionality."
 )

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -11,24 +11,24 @@ from .version import __version__
 @attr.s
 class Visitor(ast.NodeVisitor):
     """
-    ast.NodeVisitor will automatically call the appropriate method for a given node type
+    ast.NodeVisitor calls the appropriate method for a given node type
 
     i.e. calling self.visit on an Import node calls visit_import
 
     The `check` functions should be called from the `visit_` method that
-    would produce a 'fail' condition.  
+    would produce a 'fail' condition.
     """
     errors = attr.ib(default=attr.Factory(list))
 
     def visit_Import(self, node):
-        """ 
+        """
         Called for `import ..` and `import .. as ..` nodes.
         """
         self.generic_visit(node)  # continue checking children
         self.errors.extend(check_import_name(node))
 
     def visit_Call(self, node):
-        """ 
+        """
         Called for `.method()` nodes.
         """
         self.generic_visit(node)  # continue checking children
@@ -44,7 +44,7 @@ class Visitor(ast.NodeVisitor):
         self.errors.extend(check_for_merge(node))
 
     def visit_Subscript(self, node):
-        """ 
+        """
         Called for `[slicing]` nodes.
         """
         self.generic_visit(node)  # continue checking children
@@ -53,7 +53,7 @@ class Visitor(ast.NodeVisitor):
         self.errors.extend(check_for_iat(node))
 
     def visit_Attribute(self, node):
-        """ 
+        """
         Called for `.attribute` nodes.
         """
         self.errors.extend(check_for_values(node))
@@ -109,11 +109,12 @@ def check_for_notnull(node: ast.Call) -> List:
         return [PD004(node.lineno, node.col_offset)]
     return []
 
+
 def check_for_arithmetic_methods(node: ast.Call) -> List:
     """
-    Check AST for occurence of explicit arithmetic methods.  
+    Check AST for occurence of explicit arithmetic methods.
 
-    Error/warning message to recommend use of binary arithmetic operators instead.
+    Error/warning message to recommend use of binary arithmetic operators.
     """
     arithmetic_methods = [
         'add',
@@ -134,21 +135,23 @@ def check_for_arithmetic_methods(node: ast.Call) -> List:
         '%',
         ]
 
-    if isinstance(node.func, ast.Attribute) and node.func.attr in arithmetic_methods:
+    if isinstance(node.func, ast.Attribute) and \
+       node.func.attr in arithmetic_methods:
         return [PD005(node.lineno, node.col_offset)]
     return []
 
 
 def check_for_comparison_methods(node: ast.Call) -> List:
     """
-    Check AST for occurence of explicit comparison methods.  
+    Check AST for occurence of explicit comparison methods.
 
-    Error/warning message to recommend use of binary comparison operators instead.
+    Error/warning message to recommend use of binary comparison operators.
     """
     comparison_methods = ['gt', 'lt', 'ge', 'le', 'eq', 'ne']
     comparison_operators = ['>',  '<',  '>=', '<=', '==', '!=']
 
-    if isinstance(node.func, ast.Attribute) and node.func.attr in comparison_methods:
+    if isinstance(node.func, ast.Attribute) and \
+       node.func.attr in comparison_methods:
         return [PD006(node.lineno, node.col_offset)]
     return []
 
@@ -186,9 +189,9 @@ def check_for_pivot(node: ast.Call) -> List:
 
 def check_for_unstack(node: ast.Call) -> List:
     """
-    Check AST for occurence of the `.unstack()` method on the pandas data frame.
+    Check occurence of the `.unstack()` method on the pandas data frame.
 
-    Error/warning message to recommend use of `.pivot_table()` method instead.
+    Error/warning message to recommend use of `.pivot_table()` method.
     """
     if isinstance(node.func, ast.Attribute) and node.func.attr == "unstack":
         return [PD010(node.lineno, node.col_offset)]
@@ -208,16 +211,16 @@ def check_for_stack(node: ast.Call) -> List:
 
 def check_for_values(node: ast.Attribute) -> List:
     """
-    Check AST for occurence of the `.values` attribute on the pandas data frame.
+    Check occurence of the `.values` attribute on the pandas data frame.
 
-    Error/warning message to recommend use of `.array` data frame attribute for
-    PandasArray, or `.to_array()` method for NumPy array.
+    Error/warning message to recommend use of `.array` data frame attribute
+    for PandasArray, or `.to_array()` method for NumPy array.
     """
     if node.attr == "values":
         return [PD011(node.lineno, node.col_offset)]
     return []
 
-  
+
 def check_for_read_table(node: ast.Call) -> List:
     """
     Check AST for occurence of the `.read_table()` method on the pandas object.

--- a/tests/test_PD015.py
+++ b/tests/test_PD015.py
@@ -26,9 +26,18 @@ def test_PD015_pass_merge_on_dataframe():
     statement = "df1.merge(df2)"
     tree = ast.parse(statement)
     expected = []
-
     actual = list(VetPlugin(tree).run())
+    assert actual == expected
 
+
+def test_PD015_pass_merge_on_dataframe_with_multiple_args():
+    """
+    Test that using `df.merge(arg1, arg2)` does not produce an error.
+    """
+    statement = "df1.merge(df2, 'inner')"
+    tree = ast.parse(statement)
+    expected = []
+    actual = list(VetPlugin(tree).run())
     assert actual == expected
 
 
@@ -39,7 +48,5 @@ def test_PD015_fail_merge_on_pandas_object():
     statement = "pd.merge(df1, df2)"
     tree = ast.parse(statement)
     expected = [PD015(1, 0)]
-
     actual = list(VetPlugin(tree).run())
-
     assert actual == expected

--- a/tests/test_PD015.py
+++ b/tests/test_PD015.py
@@ -2,8 +2,16 @@
 Test to check for `.merge()` method on pandas root object.
 
 Although the `.merge()` method is defined for both the pandas root object
-(`pd.merge()`) and the pandas DataFrame object (`df.merge()`), the preferred
-syntax is to use the DataFrame.  
+and the pandas DataFrame object, the preferred syntax is to use the DataFrame.
+
+The only difference in the methods is that for the pandas root method, an
+additional positional parameter is required to specify the dataframe to be
+merged.  The methods are differentiated in the AST by comparing the type
+of the base object.  A definitive distinction between these methods must
+check the type of the base object.
+
+    pd.merge(left, right, how='inner', on=None, ... )
+    df.merge(right, how='inner', on=None, ... )
 """
 import ast
 
@@ -15,11 +23,12 @@ def test_PD015_pass_merge_on_dataframe():
     """
     Test that using .merge() on the dataframe does not result in an error.
     """
-    pass    ### NOT YET IMPLEMENTED
-    statement = "df.method( XXX )"
+    statement = "df1.merge(df2)"
     tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
     expected = []
+
+    actual = list(VetPlugin(tree).run())
+
     assert actual == expected
 
 
@@ -27,9 +36,10 @@ def test_PD015_fail_merge_on_pandas_object():
     """
     Test that using .merge() on the pandas root object generates an error.
     """
-    pass    ### NOT YET IMPLEMENTED
-    statement = "pd.method( XXX )"
+    statement = "pd.merge(df1, df2)"
     tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
     expected = [PD015(1, 0)]
+
+    actual = list(VetPlugin(tree).run())
+
     assert actual == expected

--- a/tests/test_PD015.py
+++ b/tests/test_PD015.py
@@ -1,0 +1,35 @@
+"""
+Test to check for `.merge()` method on pandas root object.
+
+Although the `.merge()` method is defined for both the pandas root object
+(`pd.merge()`) and the pandas DataFrame object (`df.merge()`), the preferred
+syntax is to use the DataFrame.  
+"""
+import ast
+
+from pandas_vet import VetPlugin
+from pandas_vet import PD015
+
+
+def test_PD015_pass_merge_on_dataframe():
+    """
+    Test that using .merge() on the dataframe does not result in an error.
+    """
+    pass    ### NOT YET IMPLEMENTED
+    statement = "df.method( XXX )"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
+def test_PD015_fail_merge_on_pandas_object():
+    """
+    Test that using .merge() on the pandas root object generates an error.
+    """
+    pass    ### NOT YET IMPLEMENTED
+    statement = "pd.method( XXX )"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = [PD015(1, 0)]
+    assert actual == expected


### PR DESCRIPTION
This PR addresses #25 by inferring type of the base object based on:

1. base object name is `pd`
2. `.merge()` method has at least two arguments

It would be more correct to confirm the type of the base object, however this semantic information is not available via the AST.  