### PR TITLE
Meta linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,28 @@ sudo: false
 # python settings
 language: python
 python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
   - "3.8"
+  - "3.7"
+  - "3.6"
+  - "3.5"
+
+# for use in linting and static analysis
+env:
+  - SOURCES="pandas_vet setup.py tests --exclude tests/data"
+
+# include allows has the following jobs run only against the first
+# entry in the python array. We use this because we both black and
+# flake8 only need to be run across the sources once.
+jobs:
+  include:
+    - install: pip install -r reqs/lint.txt
+      script: flake8 $SOURCES
+    - install: pip install -r reqs/lint.txt
+      script: black --check $SOURCES
 
 # install packages
 install:
-  - pip install -r requirements_test.txt
+  - pip install -r reqs/test.txt
   - pip install -e .
 
 # run test

--- a/README.md
+++ b/README.md
@@ -68,22 +68,30 @@ Because this project started during the PyCascades 2019 sprints, we adopt the Py
 
 3. Get a development environment set up with your favorite environment manager (`conda`, `virtualenv`, etc.). 
 
-    1. You can create one from `pip install -r requirements_test.txt` or, if you use Docker, you can build an image from the Dockerfile included in this repo.
+    0. You must use at least python 3.6 to develop, for [black](https://github.com/psf/black) support.
+
+    1. You can create one from `pip install -r requirements_dev.txt` or, if you use Docker, you can build an image from the Dockerfile included in this repo.
 
     2. Once your enviroment is set up you will need to install pandas-vet in development mode. Use `pip install -e .` (use this if you are alreay in your virtual enviroment) or `pip install -e <path>` (use this one if not in the virtual enviroment and prefer to state explicitly where it is going).
 
 
 4. Write code, docs, etc.
 
-5. We use `pytest` and `flake8` to validate our codebase. The TravisCI integration will complain on pull requests if there are any failing tests or lint violations. To check these locally, run the following commands:
+5. We use `pytest`, `flake8`, and `black` to validate our codebase. TravisCI integration will complain on pull requests if there are any failing tests or lint violations. To check these locally, run the following commands:
 
 ```bash
-pytest tests
+pytest --cov=pandas_vet
 ```
 
 ```bash
 flake8 pandas_vet setup.py tests --exclude tests/data
 ```
+
+```bash
+black --check pandas_vet setup.py tests --exclude tests/data
+```
+
+
 
 6. Push to your forked repo.
 

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -201,10 +201,7 @@ def check_for_arithmetic_methods(node: ast.Call) -> List:
         "mod",
     ]
 
-    if (
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr in arithmetic_methods
-    ):
+    if isinstance(node.func, ast.Attribute) and node.func.attr in arithmetic_methods:
         return [PD005(node.lineno, node.col_offset)]
     return []
 
@@ -217,10 +214,7 @@ def check_for_comparison_methods(node: ast.Call) -> List:
     """
     comparison_methods = ["gt", "lt", "ge", "le", "eq", "ne"]
 
-    if (
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr in comparison_methods
-    ):
+    if isinstance(node.func, ast.Attribute) and node.func.attr in comparison_methods:
         return [PD006(node.lineno, node.col_offset)]
     return []
 

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -152,7 +152,8 @@ def check_for_isnull(node: ast.Call) -> List:
     Approved:
         df.isna()
 
-    Error/warning message to recommend usage of .isna() instead of .isnull(). Functionality is equivalent
+    Error/warning message to recommend usage of .isna() instead of .isnull().
+    Functionality is equivalent.
 
     :param node: an AST node of type Call
     :return errors: list of errors of type PD003 with line number and column offset
@@ -171,7 +172,8 @@ def check_for_notnull(node: ast.Call) -> List:
     Approved:
         df.notna()
 
-    Error/warning message to recommend usage of .notna() instead of .notnull(). Functionality is equivalent
+    Error/warning message to recommend usage of .notna() instead of .notnull().
+    Functionality is equivalent.
 
     :param node: an AST node of type Call
     :return errors: list of errors of type PD004 with line number and column offset
@@ -380,7 +382,8 @@ PD009 = VetError(
     message="PD009 Use '.iloc' instead of '.iat'.  If speed is important, use numpy."
 )
 PD010 = VetError(
-    message="PD010 '.pivot_table' is preferred to '.pivot' or '.unstack'; provides same functionality"
+    message="PD010 '.pivot_table' is preferred to '.pivot' or '.unstack'; "
+    "provides same functionality"
 )
 PD011 = VetError(
     message="PD011 Use '.array' or '.to_array()' instead of '.values'; 'values' is ambiguous"
@@ -392,7 +395,8 @@ PD013 = VetError(
     message="PD013 '.melt' is preferred to '.stack'; provides same functionality"
 )
 PD015 = VetError(
-    message="PD015 Use '.merge' method instead of 'pd.merge' function. They have equivalent functionality."
+    message="PD015 Use '.merge' method instead of 'pd.merge' function. "
+    "They have equivalent functionality."
 )
 
 PD901 = VetError(

--- a/reqs/README.md
+++ b/reqs/README.md
@@ -1,0 +1,7 @@
+# `pandas-vet` Requirements
+
+This directory splits out requirements for different build, lint, & test related activities.
+
+This is mostly to speed up and dedupe travis jobs, which individually may only run part of the build.
+
+If you're developing `pandas-vet` follow the instructions in the master readme.

--- a/reqs/README.md
+++ b/reqs/README.md
@@ -2,6 +2,6 @@
 
 This directory splits out requirements for different build, lint, & test related activities.
 
-This is mostly to speed up and dedupe travis jobs, which individually may only run part of the build.
+This is mostly to speed up and dedupe TravisCI jobs, which individually may only run part of the build.
 
 If you're developing `pandas-vet` follow the instructions in the master README.

--- a/reqs/README.md
+++ b/reqs/README.md
@@ -4,4 +4,4 @@ This directory splits out requirements for different build, lint, & test related
 
 This is mostly to speed up and dedupe travis jobs, which individually may only run part of the build.
 
-If you're developing `pandas-vet` follow the instructions in the master readme.
+If you're developing `pandas-vet` follow the instructions in the master README.

--- a/reqs/lint.txt
+++ b/reqs/lint.txt
@@ -1,0 +1,20 @@
+# flake8, top level
+flake8==3.7.9
+
+# flake8 toolchain, transitive dependencies
+entrypoints==0.3
+mccabe==0.6.1
+pluggy==0.13.1
+pycodestyle==2.5.0
+pyflakes==2.1.1
+
+# black, top level
+black==19.10b0
+
+# black toolchain, transitive dependencies
+appdirs==1.4.3
+pathspec==0.7.0
+Click==7.0
+regex==2020.1.8
+typed-ast==1.4.1
+toml==0.10.0

--- a/reqs/test.txt
+++ b/reqs/test.txt
@@ -20,23 +20,3 @@ six==1.14.0
 wcwidth==0.1.8
 zipp==2.2.0
 
-# lint toolchain, top level
-flake8==3.7.9
-
-# lint toolchain, transitive dependencies
-entrypoints==0.3
-mccabe==0.6.1
-pluggy==0.13.1
-pycodestyle==2.5.0
-pyflakes==2.1.1
-
-# black toolchain
-black==19.10b0
-
-# black toolchain, transitive dependencies
-appdirs==1.4.3
-pathspec==0.7.0
-Click==7.0
-regex==2020.1.8
-typed-ast==1.4.1
-toml==0.10.0

--- a/reqs/test.txt
+++ b/reqs/test.txt
@@ -18,5 +18,6 @@ py==1.8.1
 pyparsing==2.4.6
 six==1.14.0
 wcwidth==0.1.8
-zipp==2.2.0
+# zipp > 1.1.0 doesn't support python 3.5, this can be dumped once 3.5 support is dropped
+zipp==1.1.0
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+-r reqs/test.txt
+-r reqs/lint.txt

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,21 @@
--r requirements.txt
-pytest>4.0.0
-pytest-cov>=2.6.1
+# build toolchain, from virtualenv/python
+pip==20.0.2
+setuptools==45.2.0
+wheel==0.34.2
 
+# test toolchain, top level
+pytest==5.3.5
+pytest-cov==2.8.1
+
+# test toolchain, transitive dependencies
+attrs==19.3.0
+coverage==5.0.3
+importlib-metadata==1.5.0
+more-itertools==8.2.0
+packaging==20.1
+pluggy==0.13.1
+py==1.8.1
+pyparsing==2.4.6
+six==1.14.0
+wcwidth==0.1.8
+zipp==2.2.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -29,3 +29,14 @@ mccabe==0.6.1
 pluggy==0.13.1
 pycodestyle==2.5.0
 pyflakes==2.1.1
+
+# black toolchain
+black==19.10b0
+
+# black toolchain, transitive dependencies
+appdirs==1.4.3
+pathspec==0.7.0
+Click==7.0
+regex==2020.1.8
+typed-ast==1.4.1
+toml==0.10.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -19,3 +19,13 @@ pyparsing==2.4.6
 six==1.14.0
 wcwidth==0.1.8
 zipp==2.2.0
+
+# lint toolchain, top level
+flake8==3.7.9
+
+# lint toolchain, transitive dependencies
+entrypoints==0.3
+mccabe==0.6.1
+pluggy==0.13.1
+pycodestyle==2.5.0
+pyflakes==2.1.1


### PR DESCRIPTION
This PR introduces flake8 and black to the toolchain and ensures they are run against every pull request.

Fixes #83.

In fact, this will categorically prevent #83 from ever regressing.

**Testing done:**

I enabled Travis on my fork.  All pushes to this branch can be seen here:

https://travis-ci.org/wadells/pandas-vet/builds?utm_medium=notification&utm_source=github_status

It is currently green.

Furthermore, I also nuked & rebuilt my venv to test setup instructions.

```
walt@wiwy:~/git/pandas-vet$ deactivate
walt@wiwy:~/git/pandas-vet$ rm -rf venv
walt@wiwy:~/git/pandas-vet$ virtualenv venv                                                                                                                                       walt@wiwy:~/git/pandas-vet$ source venv/bin/activate
walt@wiwy:~/git/pandas-vet$ pip install -r requirements_dev.txt 
Requirement already satisfied: pip==20.0.2 in ./venv/lib/python3.7/site-packages (from -r reqs/test.txt (line 2)) (20.0.2)
Requirement already satisfied: setuptools==45.2.0 in ./venv/lib/python3.7/site-packages (from -r reqs/test.txt (line 3)) (45.2.0)
Requirement already satisfied: wheel==0.34.2 in ./venv/lib/python3.7/site-packages (from -r reqs/test.txt (line 4)) (0.34.2)
Collecting pytest==5.3.5
  Using cached pytest-5.3.5-py3-none-any.whl (235 kB)
Collecting pytest-cov==2.8.1
  Using cached pytest_cov-2.8.1-py2.py3-none-any.whl (18 kB)
Collecting attrs==19.3.0
  Using cached attrs-19.3.0-py2.py3-none-any.whl (39 kB)
Collecting coverage==5.0.3
  Using cached coverage-5.0.3-cp37-cp37m-macosx_10_13_x86_64.whl (202 kB)
Collecting importlib-metadata==1.5.0
  Using cached importlib_metadata-1.5.0-py2.py3-none-any.whl (30 kB)
Collecting more-itertools==8.2.0
  Using cached more_itertools-8.2.0-py3-none-any.whl (43 kB)
Collecting packaging==20.1
  Using cached packaging-20.1-py2.py3-none-any.whl (36 kB)
Collecting pluggy==0.13.1
  Using cached pluggy-0.13.1-py2.py3-none-any.whl (18 kB)
Collecting py==1.8.1
  Using cached py-1.8.1-py2.py3-none-any.whl (83 kB)
Collecting pyparsing==2.4.6
  Using cached pyparsing-2.4.6-py2.py3-none-any.whl (67 kB)
Collecting six==1.14.0
  Using cached six-1.14.0-py2.py3-none-any.whl (10 kB)
Collecting wcwidth==0.1.8
  Using cached wcwidth-0.1.8-py2.py3-none-any.whl (17 kB)
Collecting zipp==1.1.0
  Downloading zipp-1.1.0-py2.py3-none-any.whl (4.6 kB)
Collecting flake8==3.7.9
  Using cached flake8-3.7.9-py2.py3-none-any.whl (69 kB)
Collecting entrypoints==0.3
  Using cached entrypoints-0.3-py2.py3-none-any.whl (11 kB)
Collecting mccabe==0.6.1
  Using cached mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Collecting pycodestyle==2.5.0
  Using cached pycodestyle-2.5.0-py2.py3-none-any.whl (51 kB)
Collecting pyflakes==2.1.1
  Using cached pyflakes-2.1.1-py2.py3-none-any.whl (59 kB)
Collecting black==19.10b0
  Using cached black-19.10b0-py36-none-any.whl (97 kB)
Collecting appdirs==1.4.3
  Using cached appdirs-1.4.3-py2.py3-none-any.whl (12 kB)
Collecting pathspec==0.7.0
  Using cached pathspec-0.7.0-py2.py3-none-any.whl (25 kB)
Collecting Click==7.0
  Using cached Click-7.0-py2.py3-none-any.whl (81 kB)
Processing /Users/walt/Library/Caches/pip/wheels/46/bc/80/2be94e7f74978bbc5d1a80646d53e76b0613c5507d862c2c0c/regex-2020.1.8-cp37-cp37m-macosx_10_13_x86_64.whl
Collecting typed-ast==1.4.1
  Using cached typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl (223 kB)
Collecting toml==0.10.0
  Using cached toml-0.10.0-py2.py3-none-any.whl (25 kB)
Installing collected packages: wcwidth, zipp, importlib-metadata, attrs, pluggy, more-itertools, pyparsing, six, packaging, py, pytest, coverage, pytest-cov, mccabe, entrypoints, pyflakes, pycodestyle, flake8, Click, pathspec, regex, typed-ast, toml, appdirs, black
Successfully installed Click-7.0 appdirs-1.4.3 attrs-19.3.0 black-19.10b0 coverage-5.0.3 entrypoints-0.3 flake8-3.7.9 importlib-metadata-1.5.0 mccabe-0.6.1 more-itertools-8.2.0 packaging-20.1 pathspec-0.7.0 pluggy-0.13.1 py-1.8.1 pycodestyle-2.5.0 pyflakes-2.1.1 pyparsing-2.4.6 pytest-5.3.5 pytest-cov-2.8.1 regex-2020.1.8 six-1.14.0 toml-0.10.0 typed-ast-1.4.1 wcwidth-0.1.8 zipp-1.1.0
walt@wiwy:~/git/pandas-vet$ pip install -e .
Obtaining file:///Users/walt/git/pandas-vet
Requirement already satisfied: flake8>3.0.0 in ./venv/lib/python3.7/site-packages (from pandas-vet==0.2.2) (3.7.9)
Requirement already satisfied: attrs in ./venv/lib/python3.7/site-packages (from pandas-vet==0.2.2) (19.3.0)
Requirement already satisfied: pyflakes<2.2.0,>=2.1.0 in ./venv/lib/python3.7/site-packages (from flake8>3.0.0->pandas-vet==0.2.2) (2.1.1)
Requirement already satisfied: entrypoints<0.4.0,>=0.3.0 in ./venv/lib/python3.7/site-packages (from flake8>3.0.0->pandas-vet==0.2.2) (0.3)
Requirement already satisfied: mccabe<0.7.0,>=0.6.0 in ./venv/lib/python3.7/site-packages (from flake8>3.0.0->pandas-vet==0.2.2) (0.6.1)
Requirement already satisfied: pycodestyle<2.6.0,>=2.5.0 in ./venv/lib/python3.7/site-packages (from flake8>3.0.0->pandas-vet==0.2.2) (2.5.0)
Installing collected packages: pandas-vet
  Running setup.py develop for pandas-vet
Successfully installed pandas-vet
walt@wiwy:~/git/pandas-vet$ flake8 pandas_vet setup.py tests --exclude tests/data
walt@wiwy:~/git/pandas-vet$ !black
walt@wiwy:~/git/pandas-vet$ black --verbose pandas_vet setup.py tests --exclude tests/data
pandas_vet/__pycache__/version.cpython-37.pyc ignored: matches the .gitignore file content
pandas_vet/__pycache__/__init__.cpython-37.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD001.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD012.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD004.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD901.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD013.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD005.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD015.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD003.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD010.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD006.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD009.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD011.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD007.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD002.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
tests/__pycache__/test_PD008.cpython-37-pytest-5.3.5.pyc ignored: matches the .gitignore file content
/Users/walt/git/pandas-vet/pandas_vet/version.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/setup.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD001.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD002.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD003.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD004.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD005.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD006.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD007.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD008.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD009.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD010.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD011.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD012.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD013.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD015.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/tests/test_PD901.py wasn't modified on disk since last run.
/Users/walt/git/pandas-vet/pandas_vet/__init__.py already well formatted, good job.
All done! ✨ 🍰 ✨
18 files left unchanged.
walt@wiwy:~/git/pandas-vet$ pytest tests    
============================================================ test session starts ============================================================
platform darwin -- Python 3.7.3, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /Users/walt/git/pandas-vet
plugins: cov-2.8.1
collected 41 items                                                                                                                          

tests/test_PD001.py ...                                                                                                               [  7%]
tests/test_PD002.py ..                                                                                                                [ 12%]
tests/test_PD003.py ...                                                                                                               [ 19%]
tests/test_PD004.py ..                                                                                                                [ 24%]
tests/test_PD005.py ..                                                                                                                [ 29%]
tests/test_PD006.py ..                                                                                                                [ 34%]
tests/test_PD007.py ...                                                                                                               [ 41%]
tests/test_PD008.py ..                                                                                                                [ 46%]
tests/test_PD009.py ..                                                                                                                [ 51%]
tests/test_PD010.py ...                                                                                                               [ 58%]
tests/test_PD011.py ....                                                                                                              [ 68%]
tests/test_PD012.py ...                                                                                                               [ 75%]
tests/test_PD013.py ..                                                                                                                [ 80%]
tests/test_PD015.py ....                                                                                                              [ 90%]
tests/test_PD901.py ....                                                                                                              [100%]

============================================================ 41 passed in 0.20s =============================================================
walt@wiwy:~/git/pandas-vet$ 
```