### PR TITLE
Add nox

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,22 @@ Because this project started during the PyCascades 2019 sprints, we adopt the Py
 
 2. Fork the repo and create a new branch for your enhancement/fix.
 
-3. Get a development environment set up with your favorite environment manager (`conda`, `virtualenv`, etc.). 
+3. Get a development environment set up with your favorite environment manager (`conda`, `virtualenv`, etc.).
 
-    0. You must use at least python 3.6 to develop, for [black](https://github.com/psf/black) support.
+    0. Install [nox](https://nox.thea.codes/en/stable/tutorial.html) on your local development environment.
 
-    1. You can create one from `pip install -r requirements_dev.txt` or, if you use Docker, you can build an image from the Dockerfile included in this repo.
-
-    2. Once your enviroment is set up you will need to install pandas-vet in development mode. Use `pip install -e .` (use this if you are alreay in your virtual enviroment) or `pip install -e <path>` (use this one if not in the virtual enviroment and prefer to state explicitly where it is going).
+    1. Run nox using `nox` which will setup your virtual environment.
 
 
 4. Write code, docs, etc.
 
-5. We use `pytest`, `flake8`, and `black` to validate our codebase. TravisCI integration will complain on pull requests if there are any failing tests or lint violations. To check these locally, run the following commands:
+5. We use `pytest`, `flake8`, and `black` to validate our codebase. TravisCI integration will complain on pull requests if there are any failing tests or lint violations. To check these locally, run using:
+
+```bash
+nox
+```
+
+Or alternatively, run the following commands manually:
 
 ```bash
 pytest --cov=pandas_vet

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,28 +1,28 @@
 import nox
 
 
-SOURCES = "pandas_vet setup.py tests --exclude tests/data".split()
+# TODO: set multiple versions
+# see docs at https://github.com/payscale/fables/blob/master/noxfile.py
+# py_versions = ["3.8", "3.7", "3.6"]
+SOURCES = "pandas_vet setup.py noxfile.py tests --exclude tests/data".split()
 
 
-@nox.session
+#
+@nox.session(reuse_venv=True)
+def blacken(session):
+    session.install("-r", "reqs/lint.txt")
+    session.run("black", *SOURCES)
+
+
+@nox.session(reuse_venv=True)
 def lint(session):
     session.install("-r", "reqs/lint.txt")
-    session.run("flake8", *SOURCES)
+    session.run("flake8", *SOURCES, "")
     session.run("black", "--check", *SOURCES)
 
 
-@nox.session
+@nox.session(reuse_venv=True)
 def test(session):
     session.install("-r", "reqs/test.txt")
-    # TODO: ensuring that local vet environment is setup ( pip install -e)
+    session.install("-e", ".")
     session.run("pytest", "--cov=pandas_vet")
-    session.run("flake8", "pandas_vet", "setup.py", "tests",
-                "--exclude tests/data")
-    # TODO: session.run black
-    # black --check pandas_vet setup.py tests --exclude tests/data
-
-
-@nox.session
-def install_vet_dev_mode(session):
-    """Install pandas-vet development mode"""
-    pass

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,28 @@
+import nox
+
+
+SOURCES = "pandas_vet setup.py tests --exclude tests/data".split()
+
+
+@nox.session
+def lint(session):
+    session.install("-r", "reqs/lint.txt")
+    session.run("flake8", *SOURCES)
+    session.run("black", "--check", *SOURCES)
+
+
+@nox.session
+def test(session):
+    session.install("-r", "reqs/test.txt")
+    # TODO: ensuring that local vet environment is setup ( pip install -e)
+    session.run("pytest", "--cov=pandas_vet")
+    session.run("flake8", "pandas_vet", "setup.py", "tests",
+                "--exclude tests/data")
+    # TODO: session.run black
+    # black --check pandas_vet setup.py tests --exclude tests/data
+
+
+@nox.session
+def install_vet_dev_mode(session):
+    """Install pandas-vet development mode"""
+    pass


### PR DESCRIPTION
This PR add the [nox](https://nox.thea.codes/en/stable/tutorial.html) as a starting environment for getting started with `pandas-vet`.

Issue: #86

Changes:
- [x] Adding initial nox infrastructure
- [x] Edit README to reflect new nox setup
- [ ] Test with different version of python (e.g. 3.5) to ensure nothing breaks


