### PR TITLE
Confirm pandas imported

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -120,10 +120,10 @@ def check_import_name(node: ast.Import) -> List:
     :return errors: list of errors of type PD001 with line number and column offset
     """
     errors = []
-    imports_pandas = False
+    imports_pandas = [False]
     for n in node.names:
         if n.name == "pandas":
-            imports_pandas = True
+            imports_pandas = [True]
             if n.asname != "pd":
                 errors.append(PD001(node.lineno, node.col_offset))
     return errors, imports_pandas


### PR DESCRIPTION
This PR is intended to introduce a partial fix for #74 and #81 by confirming that pandas is imported in the file before continuing with any checks. This was proposed by @wanaryytel in #74 .

This will not solve the problem for all code, but it will avoid the most egregious false positives: pandas-vet linter errors raised when the user isn't even using `pandas` (explicitly).

This will entail:
- [X] adding an attribute (`is_pandas_import`) to the `Visitor` class that will store a list of boolean values, one for each node. 
- [X] This value will be `True` when `pandas` is detected during the check
- [X] adding an `if any(self.is_pandas_import):` statement to each of the `visit_*` methods (except `visit_Import`
- [ ] updating tests to include a first line of `import pandas as pd`, otherwise none of the checks will kick off.