### PR TITLE
fix(PD011): avoid false positives for dict.values()

### DIFF
--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -73,7 +73,17 @@ class Visitor(ast.NodeVisitor):
         return self.errors
 
     def generic_visit(self, node):
-        """Called if no explicit visitor function exists for a node."""
+        """Called if no explicit visitor function exists for a node.
+
+        This also attaches breadcrumbs before visiting a node so we can
+        later look up the syntax tree. This way, there's more
+        information to decide whether or not to raise.
+
+        The breadcrumb name is `__pandas_vet_parent` (name mangled) to
+        avoid all reasonable name collisions.
+
+        .. seealso:: `check_for_values`.
+        """
         for field, value in ast.iter_fields(node):
             if isinstance(value, list):
                 for item in value:
@@ -307,9 +317,16 @@ def check_for_values(node: ast.Attribute) -> List:
 
     Error/warning message to recommend use of `.array` data frame attribute
     for PandasArray, or `.to_array()` method for NumPy array.
+
+    In order to discriminate `df.values` (where this check should raise) vs
+    calls, like `dict().values()` (where this should not), this function
+    needs to check the node breadcrumb defined at `Visitor.generic_visit`,
+    raising only in the first case.
+
+    .. seealso:: `Visitor.generic_visit`.
     """
     if node.attr == "values":
-        parent = getattr(node, "_Visitor__pandas_vet_parent")
+        parent = getattr(node, "_Visitor__pandas_vet_parent", None)
         if (
             parent
             and isinstance(parent, ast.Call)

--- a/tests/test_PD011.py
+++ b/tests/test_PD011.py
@@ -41,6 +41,17 @@ def test_PD011_fail_values():
     assert actual == expected
 
 
+def test_PD011_pass_values_call():
+    """
+    Test that using .values() attribute call does not result in an error.
+    """
+    statement = "result = {}.values()"
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected
+
+
 def test_PD011_pass_node_Name():
     """
     Test that where 'values' is a Name does NOT raise an error


### PR DESCRIPTION
fixes https://github.com/deppen8/pandas-vet/issues/106

The implementation consists of two steps:

1. We have to keep a reference of the `Call` node before visiting children
2. When visiting an `Attribute`, add some checks to make sure we raise only if we did not come from a `.values()` (`Call`)