### PR TITLE
Change recommendation from .array/.to_array() to .to_numpy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ black --check pandas_vet setup.py tests --exclude tests/data
 
 **PD010** '.pivot_table' is preferred to '.pivot' or '.unstack'; provides same functionality
 
-**PD011** Use '.array' or '.to_array()' instead of '.values'; 'values' is ambiguous
+**PD011** Use '.to_numpy()' instead of '.values'; 'values' is ambiguous
 
 **PDO12** '.read_csv' is preferred to '.read_table'; provides same functionality
 

--- a/pandas_vet/__init__.py
+++ b/pandas_vet/__init__.py
@@ -322,8 +322,7 @@ def check_for_values(node: ast.Attribute) -> List:
     """
     Check occurence of the `.values` attribute on the pandas data frame.
 
-    Error/warning message to recommend use of `.array` data frame attribute
-    for PandasArray, or `.to_array()` method for NumPy array.
+    Error/warning message to recommend use of `.to_numpy()` method for NumPy array.
 
     In order to discriminate `df.values` (where this check should raise) vs
     calls, like `dict().values()` (where this should not), this function
@@ -430,7 +429,7 @@ PD010 = VetError(
     "provides same functionality"
 )
 PD011 = VetError(
-    message="PD011 Use '.array' or '.to_array()' instead of '.values'; 'values' is ambiguous"
+    message="PD011 Use '.to_numpy()' instead of '.values'; 'values' is ambiguous"
 )
 PD012 = VetError(
     message="PDO12 '.read_csv' is preferred to '.read_table'; provides same functionality"

--- a/tests/test_PD011.py
+++ b/tests/test_PD011.py
@@ -1,6 +1,5 @@
 """
-Test to check for use of the pandas dataframe `.array` attribute
-or `.to_array()` method in preference to `.values` attribute.
+Test to check for use of the pandas dataframe `.to_numpy()` method in preference to `.values` attribute.
 """
 import ast
 
@@ -8,22 +7,11 @@ from pandas_vet import VetPlugin
 from pandas_vet import PD011
 
 
-def test_PD011_pass_to_array():
+def test_PD011_pass_to_numpy():
     """
-    Test that using .to_array() explicitly does not result in an error.
+    Test that using .to_numpy() explicitly does not result in an error.
     """
     statement = "result = df.to_array()"
-    tree = ast.parse(statement)
-    actual = list(VetPlugin(tree).run())
-    expected = []
-    assert actual == expected
-
-
-def test_PD011_pass_array():
-    """
-    Test that using .array explicitly does not result in an error.
-    """
-    statement = "result = df.array"
     tree = ast.parse(statement)
     actual = list(VetPlugin(tree).run())
     expected = []


### PR DESCRIPTION
Please complete this template for all pull requests to `pandas-vet`. It will help us to review the PR faster. Also, this format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and will help keep the change log accurate and up-to-date.

## Related issues 

- #113 

## This PR does the following:

### Added

- None

### Changed

- Change PD011 recommendation from `.array` and `.to_array()` to `.to_numpy()`

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- None


Closes #113