### PR TITLE
fix(pd002): Avoid crashing with inplace and variable

### DIFF
--- a/src/pandas_vet/__init__.py
+++ b/src/pandas_vet/__init__.py
@@ -173,7 +173,11 @@ def check_inplace_false(node: ast.Call) -> List:
     """
     errors = []
     for kw in node.keywords:
-        if kw.arg == "inplace" and kw.value.value is True:
+        if (
+            kw.arg == "inplace"
+            and hasattr(kw.value, "value")
+            and kw.value.value is True
+        ):
             errors.append(PD002(node.lineno, node.col_offset))
     return errors
 

--- a/tests/test_PD002.py
+++ b/tests/test_PD002.py
@@ -24,3 +24,16 @@ def test_PD002_fail():
     actual = list(VetPlugin(tree).run())
     expected = [PD002(1, 0)]
     assert actual == expected
+
+
+def test_PD002_with_variable_does_not_crash():
+    """
+    Test that using inplace=<some variable> does not raise Exceptions.
+
+    It will not be able to infer the value of the variable, so no errors either.
+    """
+    statement = """use_inplace=True; df.drop(['a'], axis=1, inplace=use_inplace)"""
+    tree = ast.parse(statement)
+    actual = list(VetPlugin(tree).run())
+    expected = []
+    assert actual == expected


### PR DESCRIPTION
From @KPLauritzen 

>Closes #111
>
>Fix issue where flake8 would crash when analysing an "inplace=<some variable>" statement.
>
>Adds test to avoid regression